### PR TITLE
Add newline built-in to re-prompt or keep going if the only input is …

### DIFF
--- a/_parse.c
+++ b/_parse.c
@@ -35,12 +35,17 @@ char **_parse(char *buffer, const char *delim)
 		}
 		for (j = j_store, k = 0; NOT_DELIM; j++, k++)
 			args[i][k] = buffer[j];
-		if (i == (arg_count - 1) && buffer[j - 1] == '\n')
-			k--;
-
+		if (j_store != 0)
+		{
+			if (i == (arg_count - 1) && buffer[j - 1] == '\n')
+				k--;
+		}
 		args[i][k] = '\0';
-		while (buffer[j + 1] == delim[0])
-			j++;
+		if (buffer[j] != '\0')
+		{
+			while (buffer[j + 1] == delim[0])
+				j++;
+		}
 	}
 	args[i] = NULL;
 	return (args);

--- a/arg_count.c
+++ b/arg_count.c
@@ -21,7 +21,7 @@ ssize_t arg_counting(char **buffer, const char *delim)
 		arg_count++;
 	for (i = 0; (*buffer)[i]; i++)
 	{
-		if ((*buffer)[i] == '\n')
+		if ((*buffer)[i] == '\n' && i != 0)
 		{
 			(*buffer)[i] = delim[0];
 			break;

--- a/errors_void.c
+++ b/errors_void.c
@@ -7,8 +7,9 @@
 void malloc_error(void)
 {
 	/* Error message from malloc man page, exit status from ENOMEM */
-	perror("ENOMEM Out of memory.  Possibly, the application hit the ");
-	perror("RLIMIT_AS or RLIMIT_DATA limit described in getrlimit(2).\n");
+	char *string = "ENOMEM Out of memory.";
+
+	write(STDERR, string, _strlen(string));
 	exit(12);
 }
 

--- a/header.h
+++ b/header.h
@@ -17,6 +17,7 @@ extern char **environ;
 /* SCRIPTS & DEFINITIONS */
 #define STDIN STDIN_FILENO
 #define STDOUT STDOUT_FILENO
+#define STDERR STDERR_FILENO
 
 /* FUNCTION PROTOTYPES */
 /* declaration of function to get the lenth of a string */

--- a/shelly.c
+++ b/shelly.c
@@ -8,29 +8,24 @@
 int main(void)
 {
 	char *buffer, *path, *prompt = "$ ";
-	ssize_t BUFF_SIZE = 1024;
-	ssize_t w = 0;
+	ssize_t BUFF_SIZE = 1024, w = 0;
 	const char *space = " ";
 	char **args;
 	int user_input = 0, check_path = 0, stat_check = 0;
 
 	while (1)
 	{
-		buffer = malloc(sizeof(char) * BUFF_SIZE);
-		if (buffer == NULL)
-			malloc_error();
 		if (isatty(STDIN))
 		{
 			user_input = 1;
 			w = write(STDOUT, prompt, _strlen(prompt));
 			if (w < 0)
-			{
-				free(buffer);
 				write_error();
-			}
 		}
+		buffer = malloc(sizeof(char) * BUFF_SIZE);
+		if (buffer == NULL)
+			malloc_error();
 		_getline(&buffer, &BUFF_SIZE, stdin, user_input, stat_check);
-		stat_check = 0;
 		while (buffer != NULL)
 		{
 			args = _parse(buffer, space);
@@ -48,7 +43,10 @@ int main(void)
 			buffer = reset(&buffer, &args, space);
 			if (_strcmp(args[0], "exit") == 0)
 				goodbye(&buffer, &args);
-			if (_strcmp(args[0], "env"))
+			stat_check = 0;
+			if (_strcmp(args[0], "\n") == 0)
+				check_path = 0;
+			else if (_strcmp(args[0], "env"))
 			{
 				check_path = 1;
 				stat_check = check_execute(&path, &args, &buffer);


### PR DESCRIPTION
…a newline, adjust handling of arguments to avoid reading past buffer and to account for newline, valgrind is error free both in interactive and non-interactive mode and all local tests pass