### PR TITLE
Add restrictions to delimiter type to not move past double : in PATH …

### DIFF
--- a/_parse.c
+++ b/_parse.c
@@ -43,7 +43,7 @@ char **_parse(char *buffer, char *delim)
 		args[i][k] = '\0';
 		if (buffer[j] != '\0')
 		{
-			while (buffer[j + 1] == delim[0])
+			while (buffer[j + 1] == delim[0] && delim[0] != ':')
 				j++;
 		}
 	}

--- a/arg_count.c
+++ b/arg_count.c
@@ -29,7 +29,7 @@ ssize_t arg_counting(char **buffer, char *delim)
 		if ((*buffer)[i] == delim[0])
 		{
 			arg_count++;
-			while ((*buffer)[i + 1] == delim[0])
+			while ((*buffer)[i + 1] == delim[0] && delim[0] != ':')
 				i++;
 			if ((*buffer)[i + 1] == '\n' || (*buffer)[i + 1] == '|')
 			{

--- a/check_execute.c
+++ b/check_execute.c
@@ -25,9 +25,9 @@ void check_exec(char **path, char ***args, char **buffer, int *sts, int lc)
 	if ((*sts) != 0)
 	{
 		count = itoa(lc);
-		write(STDERR, (*args)[0], _strlen((*args)[0]));
-		write(STDERR, ": ", 2);
 		write(STDERR, count, _strlen(count));
+		write(STDERR, ": ", 2);
+		write(STDERR, (*args)[0], _strlen((*args)[0]));
 		write(STDERR, ": not found\n", 13);
 		free(count);
 		*sts = 127;


### PR DESCRIPTION
…and to add empty string at that location; Update order of error message to match sh